### PR TITLE
Performance improvement: Bulk writes for customer/loader/load endpoint

### DIFF
--- a/src/main/java/com/acmeair/loader/CustomerLoader.java
+++ b/src/main/java/com/acmeair/loader/CustomerLoader.java
@@ -17,13 +17,15 @@
 package com.acmeair.loader;
 
 import com.acmeair.service.CustomerService;
-
-import java.util.logging.Logger;
+import com.acmeair.web.dto.AddressInfo;
+import com.acmeair.web.dto.CustomerInfo;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
 
 @ApplicationScoped
 public class CustomerLoader {
@@ -50,7 +52,7 @@ public class CustomerLoader {
    * Load customer db.
    */
   public String loadCustomerDb(long numCustomers) {
-
+    List<CustomerInfo> customers = new ArrayList();
     double length = 0;
     try {
      
@@ -58,13 +60,12 @@ public class CustomerLoader {
       long start = System.currentTimeMillis(); 
       customerService.dropCustomers();
 
-      String addressJson =  "{streetAddress1 : \"123 Main St.\", streetAddress2 :null, city: "
-          + "\"Anytown\", stateProvince: \"NC\", country: \"USA\", postalCode: \"27617\"}";
-
+      AddressInfo addressInfo =  new AddressInfo("123 Main St.", null, "Anytown", "NC", "USA", "27617");
       for (long ii = 0; ii < numCustomers; ii++) {
-        customerService.createCustomer("uid" + ii + "@email.com", "password", "GOLD", 0, 0, 
-            "919-123-4567", "BUSINESS", addressJson);
+        customers.add(new CustomerInfo("uid" + ii + "@email.com", "password", "GOLD", 0, 0,
+                addressInfo, "919-123-4567", "BUSINESS"));
       }
+      customerService.createCustomers(customers);
 
       long stop = System.currentTimeMillis();
       logger.info("Finished loading in " + (stop - start) / 1000.0 + " seconds");

--- a/src/main/java/com/acmeair/service/CustomerService.java
+++ b/src/main/java/com/acmeair/service/CustomerService.java
@@ -16,15 +16,16 @@
 
 package com.acmeair.service;
 
+import com.acmeair.web.dto.AddressInfo;
 import com.acmeair.web.dto.CustomerInfo;
-
-import java.io.StringReader;
 
 import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import javax.json.JsonReaderFactory;
+import java.io.StringReader;
+import java.util.List;
 
 public abstract class CustomerService {
   protected static final int DAYS_TO_ALLOW_SESSION = 1;
@@ -33,12 +34,11 @@ public abstract class CustomerService {
   @Inject
   protected KeyGenerator keyGenerator; 
  
-  public abstract void createCustomer(String username, String password, String status, 
-      int totalMiles, int milesYtd, String phoneNumber, String phoneNumberType, 
-      String addressJson);
+  public abstract void createCustomer(CustomerInfo customerInfo);
 
-  public abstract String createAddress(String streetAddress1, String streetAddress2, 
-      String city, String stateProvince, String country, String postalCode);
+  public abstract void createCustomers(List<CustomerInfo> customers);
+
+  public abstract String createAddress(AddressInfo addressInfo);
 
   public abstract void updateCustomer(String username, CustomerInfo customerJson);
 


### PR DESCRIPTION
Original implementation is using `db.collection.insertOne` method which is inefficient for bulk writes. This PR solves this inefficiency by using `db.collection.insertMany`

**insertOne**: Loaded 10000 customers in 4.421 seconds | Loaded 1000000 customers in 123.423 
**insertMany**:    Loaded 10000 customers in 0.446 seconds | Loaded 1000000 customers in 18.427